### PR TITLE
Support second-class objects where rerun not possible

### DIFF
--- a/src/classes/CaseCommentDebugWorkflow.cls
+++ b/src/classes/CaseCommentDebugWorkflow.cls
@@ -1,0 +1,24 @@
+/**
+ * This class exists for functional validation of expected framework behavior
+ * and can be delete from a Produciton organization.
+ *
+ * @see https://github.com/martyychang/sf-trigger-workflow/issues/1
+ */
+public class CaseCommentDebugWorkflow extends AbstractSobjectWorkflow {
+
+    public override void executeAfter() {
+        System.debug('AFTER');
+    }
+
+    public override void executeBefore() {
+        System.debug('BEFORE');
+    }
+
+    public override String getClassName() {
+        return CaseCommentDebugWorkflow.class.getName();
+    }
+
+    public override Boolean qualify(Sobject newRecord, Sobject oldRecord) {
+        return false;
+    }
+}

--- a/src/classes/CaseCommentDebugWorkflow.cls-meta.xml
+++ b/src/classes/CaseCommentDebugWorkflow.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>39.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/src/classes/CaseCommentDebugWorkflowTest.cls
+++ b/src/classes/CaseCommentDebugWorkflowTest.cls
@@ -40,7 +40,7 @@ private class CaseCommentDebugWorkflowTest {
                 'Number of Case Comments');
     }
 
-    @isTest
+    @testSetup
     private static void setup() {
         
         // Create accounts

--- a/src/classes/CaseCommentDebugWorkflowTest.cls
+++ b/src/classes/CaseCommentDebugWorkflowTest.cls
@@ -1,0 +1,75 @@
+/**
+ * This class exists for functional validation of expected framework behavior
+ * and can be delete from a Produciton organization.
+ *
+ * @see https://github.com/martyychang/sf-trigger-workflow/issues/1
+ */
+@isTest
+private class CaseCommentDebugWorkflowTest {
+
+    @isTest
+    private static void insertComment() {
+
+        // Given
+        Case carrotCase = [
+            SELECT Id, (SELECT Id FROM CaseComments)
+            FROM Case
+            WHERE Subject = 'My carrots are not fresh! (TEST)'
+        ];
+
+        System.assertEquals(1, carrotCase.CaseComments.size(),
+                'Number of Case Comments');
+
+        // When
+        Test.startTest();
+
+        insert new CaseComment(
+                ParentId = carrotCase.Id,
+                CommentBody = 'No, really they were from yesterday');
+
+        // Then
+        Test.stopTest();
+
+        carrotCase = [
+            SELECT Id, (SELECT Id FROM CaseComments)
+            FROM Case
+            WHERE Subject = 'My carrots are not fresh! (TEST)'
+        ];
+
+        System.assertEquals(2, carrotCase.CaseComments.size(),
+                'Number of Case Comments');
+    }
+
+    @isTest
+    private static void setup() {
+        
+        // Create accounts
+        Account acme = new Account(
+                Name = 'Acme Corporation (TEST)');
+
+        insert new List<Account> { acme };
+
+        // Create contacts
+        Contact bugs = new Contact(
+                FirstName = 'Bugs',
+                LastName = 'Bunny (TEST)',
+                AccountId = acme.Id);
+
+        insert new List<Contact> { bugs };
+
+        // Create cases
+        Case carrotCase = new Case(
+                AccountId = acme.Id,
+                ContactId = bugs.Id,
+                Subject = 'My carrots are not fresh! (TEST)');
+
+        insert new List<Case> { carrotCase };
+
+        // Create case comments
+        CaseComment carrotCaseComment1 = new CaseComment(
+                ParentId = carrotCase.Id,
+                CommentBody = 'They were procured yesterday.');
+
+        insert new List<CaseComment> { carrotCaseComment1 };
+    }
+}

--- a/src/classes/CaseCommentDebugWorkflowTest.cls-meta.xml
+++ b/src/classes/CaseCommentDebugWorkflowTest.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>39.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/src/classes/TriggerService.cls
+++ b/src/classes/TriggerService.cls
@@ -84,7 +84,19 @@ global with sharing class TriggerService {
 
         // Update the context for the service
         TriggerService service = servicesByName.get(name);
-        refreshContext(service);
+
+        // If the object supports rerun workflows, refresh the context if
+        // a rerun scenario is possible. Since delete operations cannot possibly
+        // cause a rerun, we only need to check for reruns for non-delete 
+        // DML operations. More specifically, reruns themselves manifest
+        // as update operations, so we only need to check whether the current
+        // DML context is `before update`..
+        if (Trigger.isBefore && Trigger.isUpdate) {
+            if (TriggerWorkflowUtil.isRerunSupported(
+                    Trigger.new[0].getSObjectType())) {
+                refreshContext(service);
+            }
+        }
 
         // Return the singleton service
         return service;
@@ -169,13 +181,19 @@ global with sharing class TriggerService {
      * trigger is executing again as a result of a field update.
      */
     global static void refreshContext(TriggerService service) {
-        if (Trigger.isBefore) {
-            for (Sobject eachRecord : Trigger.new) {
-                if (eachRecord.get('IsProcessed__c') == true) {
-                    service.context.isRerun = true;
-                    eachRecord.put('IsProcessed__c', false);
-                }
+
+        // Assume not a rerun
+        Boolean rerun = false;
+
+        // Check the records and unset `IsProcessed__c` if a rerun is detected
+        for (Sobject eachRecord : Trigger.new) {
+            if (eachRecord.get('IsProcessed__c') == true) {
+                rerun = true;
+                eachRecord.put('IsProcessed__c', false);
             }
         }
+        
+        // Set the context correctly
+        service.context.isRerun = rerun;
     }
 }

--- a/src/classes/TriggerWorkflowUtil.cls
+++ b/src/classes/TriggerWorkflowUtil.cls
@@ -1,0 +1,21 @@
+global class TriggerWorkflowUtil {
+
+    /**
+     * Given an `SObjectType`, determine whether the object supports
+     * rerunnable trigger workflows by checking for the existence of
+     * an `IsProcessed__c` field
+     *
+     * @param objectType
+     *
+     * @return `true` if the object supports rerunnable trigger workflows;
+     *         `false` otherwise
+     */
+    global static Boolean isRerunSupported(Schema.SObjectType objectType) {
+
+        // Get the object's describe info
+        Schema.DescribeSObjectResult objectDesc = objectType.getDescribe();
+
+        // Return whether the object has an `IsProcessed__c` field
+        return objectDesc.fields.getMap().containsKey('IsProcessed__c');
+    }
+}

--- a/src/classes/TriggerWorkflowUtil.cls-meta.xml
+++ b/src/classes/TriggerWorkflowUtil.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>39.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/src/customMetadata/TriggerWorkflow.CaseCommentDebugWorkflow.md
+++ b/src/customMetadata/TriggerWorkflow.CaseCommentDebugWorkflow.md
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomMetadata xmlns="http://soap.sforce.com/2006/04/metadata" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <label>CaseCommentDebugWorkflow</label>
+    <protected>false</protected>
+    <values>
+        <field>IsActive__c</field>
+        <value xsi:type="xsd:boolean">true</value>
+    </values>
+</CustomMetadata>

--- a/src/package.xml
+++ b/src/package.xml
@@ -11,6 +11,7 @@
         <members>TriggerContext</members>
         <members>TriggerService</members>
         <members>TriggerWorkflow</members>
+        <members>TriggerWorkflowUtil</members>
         <name>ApexClass</name>
     </types>
     <types>
@@ -21,6 +22,7 @@
     <types>
         <members>TriggerWorkflow.ApexTruthTrackDmlWorkflow</members>
         <members>TriggerWorkflow.ApexTruthTrackTriggerWorkflow</members>
+        <members>TriggerWorkflow.CaseCommentDebugWorkflow</members>
         <name>CustomMetadata</name>
     </types>
     <types>

--- a/src/package.xml
+++ b/src/package.xml
@@ -6,6 +6,8 @@
         <members>ApexTruthTrackDmlWorkflowTest</members>
         <members>ApexTruthTrackTriggerWorkflow</members>
         <members>ApexTruthTrackTriggerWorkflowTest</members>
+        <members>CaseCommentDebugWorkflow</members>
+        <members>CaseCommentDebugWorkflowTest</members>
         <members>TriggerContext</members>
         <members>TriggerService</members>
         <members>TriggerWorkflow</members>
@@ -13,6 +15,7 @@
     </types>
     <types>
         <members>ApexTruthTrigger</members>
+        <members>CaseCommentWorkflowTrigger</members>
         <name>ApexTrigger</name>
     </types>
     <types>

--- a/src/triggers/CaseCommentWorkflowTrigger.trigger
+++ b/src/triggers/CaseCommentWorkflowTrigger.trigger
@@ -1,0 +1,21 @@
+/**
+ * This trigger exists for functional validation of expected framework behavior
+ * and can be delete from a Produciton organization.
+ *
+ * @see https://github.com/martyychang/sf-trigger-workflow/issues/1
+ */
+trigger CaseCommentWorkflowTrigger on CaseComment (
+        before insert, after insert,
+        before update, after update,
+        before delete, after delete, after undelete) {
+
+    // For readability, get a handle on the TriggerService object
+    // for this Sobject type
+    TriggerService service = TriggerService.getInstance(
+            Schema.sobjectType.CaseComment.getName());
+
+    // Process all of the trigger workflows
+    service.process(new List<Type> {
+        CaseCommentDebugWorkflow.class
+    });
+}

--- a/src/triggers/CaseCommentWorkflowTrigger.trigger-meta.xml
+++ b/src/triggers/CaseCommentWorkflowTrigger.trigger-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexTrigger xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>39.0</apiVersion>
+    <status>Active</status>
+</ApexTrigger>


### PR DESCRIPTION
This pr fixes #1 by adding support for second-class objects like `CaseComment` where it's not possible to create an `IsProcessed__c` field to handle rerunnable trigger workflows.