### PR TITLE
Minimize SOQL queries used to check workflow activation

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,7 @@ Let's say you're creating your first trigger on the Account object, and you want
 
 ### One-time Account object setup
 
-1. Create an unchecked-by-default checkbox field _named_ `IsProcessed__c` on the Account object.
-2. Create and _activate_ a workflow rule on the Account object that always sets `IsProcessed__c` to TRUE.
-3. Create a single trigger on the Account object named `AccountTrigger` as shown below.
+Create a single trigger on the Account object named `AccountTrigger` as shown below.
 
 ```java
 trigger AccountTrigger on Account (
@@ -30,9 +28,7 @@ trigger AccountTrigger on Account (
             Schema.sobjectType.Account.getName());
 
     // Process all of the trigger workflows
-    service.process(new List<Type> {
-        /* This is where your trigger workflows go */
-    });
+    service.processActiveWorkflows();
 }
 ```
 
@@ -82,30 +78,6 @@ methods at a minimum must be overridden.
 * `qualify` defines the entry criteria
 
 It's fine to do nothing in either `executeBefore` or `executeAfter`, but the methods must be overridden. This has the benefit of showing the reader at a glance that something or nothing is supposed to happen in either the `before` or `after` contexts.
-
-### Add AccountCapitalizeWorkflow as a trigger workflow to process
-
-```java
-trigger AccountTrigger on Account (
-        before insert, after insert,
-        before update, after update,
-        before delete, after delete, after undelete) {
-
-    // For readability, get a handle on the TriggerService object
-    // for this Sobject type
-    TriggerService service = TriggerService.getInstance(
-            Schema.sobjectType.Account.getName());
-
-    // Process all of the trigger workflows
-    service.process(new List<Type> {
-        AccountCapitalizeWorkflow.class  // New!
-    });
-}
-```
-
-This is a single trigger that handles all trigger events. The service is object-specific, so `TriggerService.getInstance` is used to get the appropriate service for the Account object.
-
-The `process` method is called on the service to process an ordered list of workflows, where each workflow is added by its Apex type (i.e., class) via the `class` property.
 
 ### Define the trigger workflow for AccountCapitalizeWorkflow
 

--- a/README.md
+++ b/README.md
@@ -60,14 +60,6 @@ public class AccountCapitalizeWorkflow extends AbstractSobjectWorkflow {
             eachAccount.Name = eachAccount.Name.toUpperCase();
         }
     }
-    
-    /**
-     * Used to check against custom metadata to see whether the workflow
-     * is active and should be evaluated.
-     */
-    public override String getClassName() {
-        return AccountCapitalizeWorkflow.class.getName();
-    }
 
     /**
      * This is where entry criteria are defined, similar to

--- a/force-app/main/default/classes/AbstractSobjectWorkflow.cls
+++ b/force-app/main/default/classes/AbstractSobjectWorkflow.cls
@@ -106,24 +106,6 @@ global abstract with sharing class AbstractSobjectWorkflow
     global abstract void executeAfter();
 
     /**
-     * @return the workflow name for use in locating the custom metadata
-     *         for the workflow implementation
-     */
-    global abstract String getClassName();
-
-    /**
-     * @return whether the custom metadata for this workflow indicates that
-     *         the workflow is active and may be evaluated
-     */
-    global Boolean isActive() {
-        return [
-            SELECT IsActive__c
-            FROM TriggerWorkflow__mdt
-            WHERE DeveloperName = :this.getClassName()
-        ].IsActive__c;
-    }
-
-    /**
      * TODO: Actually implement logic to detect and handle recursion.
      *
      * @return false by default, the workflow does not support recursion or

--- a/force-app/main/default/classes/ApexTruthTrackDmlWorkflow.cls
+++ b/force-app/main/default/classes/ApexTruthTrackDmlWorkflow.cls
@@ -11,10 +11,6 @@ global with sharing class ApexTruthTrackDmlWorkflow
         }
     }
 
-    global override String getClassName() {
-        return ApexTruthTrackDmlWorkflow.class.getName();
-    }
-
     /**
      * Any time there's a DML operation we should be tracking that an operation
      * occurred.

--- a/force-app/main/default/classes/ApexTruthTrackTriggerWorkflow.cls
+++ b/force-app/main/default/classes/ApexTruthTrackTriggerWorkflow.cls
@@ -11,10 +11,6 @@ global with sharing class ApexTruthTrackTriggerWorkflow
         }
     }
 
-    global override String getClassName() {
-        return ApexTruthTrackTriggerWorkflow.class.getName();
-    }
-
     global override Boolean isRerunnable() {
         return true;
     }

--- a/force-app/main/default/classes/CaseCommentDebugWorkflow.cls
+++ b/force-app/main/default/classes/CaseCommentDebugWorkflow.cls
@@ -14,10 +14,6 @@ public class CaseCommentDebugWorkflow extends AbstractSobjectWorkflow {
         System.debug('BEFORE');
     }
 
-    public override String getClassName() {
-        return CaseCommentDebugWorkflow.class.getName();
-    }
-
     public override Boolean qualify(Sobject newRecord, Sobject oldRecord) {
         return false;
     }

--- a/force-app/main/default/classes/TriggerService.cls
+++ b/force-app/main/default/classes/TriggerService.cls
@@ -34,6 +34,8 @@
  */
 global with sharing class TriggerService {
 
+    private List<TriggerWorkflow> activeWorkflows { get; set; }
+
     /**
      * Additional context for the trigger not provided natively
      */
@@ -47,6 +49,8 @@ global with sharing class TriggerService {
     private static final Map<String, TriggerService> servicesByName =
             new Map<String, TriggerService>();
 
+    private String sobjectName { get; set; }
+
     /**
      * The service-specfiic registry of invoked workflows, used to return
      * the same workflow for processing continuity when a workflow has
@@ -55,13 +59,36 @@ global with sharing class TriggerService {
      */
     private Map<String, TriggerWorkflow> workflowsByName { get; set; }
 
-    /**
-     * Default constructor whose main purpose is to initialize the registry
-     * of invoked workflows.
-     */
-    public TriggerService() {
+    global TriggerService(String sobjectName) {
+        this.sobjectName = sobjectName;
+        this.activeWorkflows = new List<TriggerWorkflow>();
+        
         this.context = new TriggerContext();
         this.workflowsByName = new Map<String, TriggerWorkflow>();
+    }
+
+    global List<TriggerWorkflow> getActiveWorkflows() {
+
+        // If there are no workflows cached, look for active ones
+        if (this.activeWorkflows.isEmpty()) {
+            for (TriggerWorkflow__mdt eachEntry : [
+                SELECT
+                    DeveloperName,
+                    Id
+                FROM TriggerWorkflow__mdt
+                WHERE
+                    SobjectName__c = :this.sobjectName AND
+                    IsActive__c = TRUE
+                ORDER BY
+                    Priority__c ASC
+            ]) {
+                this.activeWorkflows.add(
+                        this.getWorkflow(eachEntry.DeveloperName));
+            }
+        }
+
+        // Return the remembered, cached workflows
+        return this.activeWorkflows;
     }
 
     /**
@@ -79,7 +106,7 @@ global with sharing class TriggerService {
         // If no service has been initialized yet for the given Sobject,
         // first initialize and register the service.
         if (!servicesByName.containsKey(name)) {
-            servicesByName.put(name, new TriggerService());
+            servicesByName.put(name, new TriggerService(name));
         }
 
         // Update the context for the service
@@ -100,6 +127,10 @@ global with sharing class TriggerService {
 
         // Return the singleton service
         return service;
+    }
+
+    global TriggerWorkflow getWorkflow(String workflowName) {
+        return this.getWorkflow(workflowName, Type.forName(workflowName));
     }
 
     /**
@@ -125,14 +156,14 @@ global with sharing class TriggerService {
      *
      * @return the appropriate workflow for the given context
      */
-    global TriggerWorkflow getWorkflow(Type workflowType) {
+    global TriggerWorkflow getWorkflow(String workflowName, Type workflowType) {
 
         // We know that every time we hit a before context, a new workflow
         // object must be constructed. The only complication is that in the
         // after context, we need to check whether a workflow object has
         // already been constructed and should be returned.
         Boolean isRegistered =
-                this.workflowsByName.containsKey(workflowType.getName());
+                this.workflowsByName.containsKey(workflowName);
 
         if (Trigger.isBefore || !isRegistered) {
 
@@ -141,37 +172,22 @@ global with sharing class TriggerService {
                     (TriggerWorkflow)workflowType.newInstance();
 
             // Register the workflow
-            this.workflowsByName.put(workflowType.getName(), workflow);
+            this.workflowsByName.put(workflowName, workflow);
         }
 
         // Return the registered workflow
-        return this.workflowsByName.get(workflowType.getName());
+        return this.workflowsByName.get(workflowName);
     }
 
     /**
      * Given a list of TriggerWorkflow subclass types, perform the appropriate
      * workflow actions for each type, carefully managing interdependencies
      * and recursion considerations.
-     *
-     * @param workflowTypes
-     *.           A list of types, for example, as expected from 
-     *            LeadAssignWorkflow.class
      */
-    global void process(List<Type> workflowTypes) {
-        for (Type eachType : workflowTypes) {
-            
-            // Get the workfow, trusting the getter to return an appropriate
-            // workflow for the given context. Specifically, it'd be awesome
-            // to get one instance of the workflow for continuity of execution
-            // between the before context and the after context.
-            TriggerWorkflow workflow = this.getWorkflow(eachType);
-
-            // Evaluate the workflow's entry criteria, then execute the workflow
-            // if there are any qualifying records to process.
-            if (workflow.isActive()) {
-                if (workflow.withContext(this.context).evaluate()) {
-                    workflow.execute();
-                }
+    global void process(List<TriggerWorkflow> workflows) {
+        for (TriggerWorkflow eachWorkflow : workflows) {
+            if (eachWorkflow.withContext(this.context).evaluate()) {
+                eachWorkflow.execute();
             }
         }
     }

--- a/force-app/main/default/classes/TriggerService.cls
+++ b/force-app/main/default/classes/TriggerService.cls
@@ -193,6 +193,14 @@ global with sharing class TriggerService {
     }
 
     /**
+     * Convenience method for processing all active workflows instead of
+     * calling `process` with the results from `getActiveWorkflows`
+     */
+    global void processActiveWorkflows() {
+        this.process(this.getActiveWorkflows());
+    }
+
+    /**
      * Refresh the context for a service, specifically to note whether the
      * trigger is executing again as a result of a field update.
      */

--- a/force-app/main/default/classes/TriggerWorkflow.cls
+++ b/force-app/main/default/classes/TriggerWorkflow.cls
@@ -12,14 +12,6 @@ global interface TriggerWorkflow {
     void execute();
 
     /**
-     * @return whether the implementation is active and should be evaluated.
-     *.        This should be integrated with the Trigger Workflow custom
-     *         metadata type for clicks-not-code control over which workflows
-     *         can be evaluated and executed and which ones cannot.
-     */
-    Boolean isActive();
-
-    /**
      * @return whether the implementation supports recursion or not
      */
     Boolean isRecursive();

--- a/force-app/main/default/customMetadata/TriggerWorkflow.ApexTruthTrackDmlWorkflow.md-meta.xml
+++ b/force-app/main/default/customMetadata/TriggerWorkflow.ApexTruthTrackDmlWorkflow.md-meta.xml
@@ -1,9 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CustomMetadata xmlns="http://soap.sforce.com/2006/04/metadata" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
     <label>ApexTruthTrackDmlWorkflow</label>
-    <protected>false</protected>
+    <protected>true</protected>
     <values>
         <field>IsActive__c</field>
         <value xsi:type="xsd:boolean">true</value>
+    </values>
+    <values>
+        <field>Priority__c</field>
+        <value xsi:type="xsd:double">100.0</value>
+    </values>
+    <values>
+        <field>SobjectName__c</field>
+        <value xsi:type="xsd:string">ApexTruth__c</value>
     </values>
 </CustomMetadata>

--- a/force-app/main/default/customMetadata/TriggerWorkflow.ApexTruthTrackTriggerWorkflow.md-meta.xml
+++ b/force-app/main/default/customMetadata/TriggerWorkflow.ApexTruthTrackTriggerWorkflow.md-meta.xml
@@ -1,9 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CustomMetadata xmlns="http://soap.sforce.com/2006/04/metadata" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
     <label>ApexTruthTrackTriggerWorkflow</label>
-    <protected>false</protected>
+    <protected>true</protected>
     <values>
         <field>IsActive__c</field>
         <value xsi:type="xsd:boolean">true</value>
+    </values>
+    <values>
+        <field>Priority__c</field>
+        <value xsi:type="xsd:double">100.0</value>
+    </values>
+    <values>
+        <field>SobjectName__c</field>
+        <value xsi:type="xsd:string">ApexTruth__c</value>
     </values>
 </CustomMetadata>

--- a/force-app/main/default/customMetadata/TriggerWorkflow.CaseCommentDebugWorkflow.md-meta.xml
+++ b/force-app/main/default/customMetadata/TriggerWorkflow.CaseCommentDebugWorkflow.md-meta.xml
@@ -1,9 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CustomMetadata xmlns="http://soap.sforce.com/2006/04/metadata" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
     <label>CaseCommentDebugWorkflow</label>
-    <protected>false</protected>
+    <protected>true</protected>
     <values>
         <field>IsActive__c</field>
         <value xsi:type="xsd:boolean">true</value>
+    </values>
+    <values>
+        <field>Priority__c</field>
+        <value xsi:type="xsd:double">100.0</value>
+    </values>
+    <values>
+        <field>SobjectName__c</field>
+        <value xsi:type="xsd:string">ApexTruth__c</value>
     </values>
 </CustomMetadata>

--- a/force-app/main/default/layouts/TriggerWorkflow__mdt-Trigger Workflow Layout.layout-meta.xml
+++ b/force-app/main/default/layouts/TriggerWorkflow__mdt-Trigger Workflow Layout.layout-meta.xml
@@ -63,6 +63,8 @@
         <detailHeading>false</detailHeading>
         <editHeading>false</editHeading>
         <layoutColumns/>
+        <layoutColumns/>
+        <layoutColumns/>
         <style>CustomLinks</style>
     </layoutSections>
     <showEmailCheckbox>false</showEmailCheckbox>

--- a/force-app/main/default/layouts/TriggerWorkflow__mdt-Trigger Workflow Layout.layout-meta.xml
+++ b/force-app/main/default/layouts/TriggerWorkflow__mdt-Trigger Workflow Layout.layout-meta.xml
@@ -22,6 +22,10 @@
                 <behavior>Required</behavior>
                 <field>Priority__c</field>
             </layoutItems>
+            <layoutItems>
+                <behavior>Required</behavior>
+                <field>SobjectName__c</field>
+            </layoutItems>
         </layoutColumns>
         <layoutColumns>
             <layoutItems>

--- a/force-app/main/default/layouts/TriggerWorkflow__mdt-Trigger Workflow Layout.layout-meta.xml
+++ b/force-app/main/default/layouts/TriggerWorkflow__mdt-Trigger Workflow Layout.layout-meta.xml
@@ -18,6 +18,10 @@
                 <behavior>Edit</behavior>
                 <field>IsActive__c</field>
             </layoutItems>
+            <layoutItems>
+                <behavior>Required</behavior>
+                <field>Priority__c</field>
+            </layoutItems>
         </layoutColumns>
         <layoutColumns>
             <layoutItems>

--- a/force-app/main/default/objects/TriggerWorkflow__mdt/fields/Priority__c.field-meta.xml
+++ b/force-app/main/default/objects/TriggerWorkflow__mdt/fields/Priority__c.field-meta.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Priority__c</fullName>
+    <defaultValue>100</defaultValue>
+    <description>The relative priority of a workflow in the context of other workflows for the same object. Multiple workflows may have the same priority if the order of operations is not important.</description>
+    <externalId>false</externalId>
+    <fieldManageability>SubscriberControlled</fieldManageability>
+    <inlineHelpText>The relative priority of a workflow in the context of other workflows for the same object. Multiple workflows may have the same priority if the order of operations is not important.</inlineHelpText>
+    <label>Priority</label>
+    <precision>4</precision>
+    <required>true</required>
+    <scale>0</scale>
+    <type>Number</type>
+    <unique>false</unique>
+</CustomField>

--- a/force-app/main/default/objects/TriggerWorkflow__mdt/fields/SobjectName__c.field-meta.xml
+++ b/force-app/main/default/objects/TriggerWorkflow__mdt/fields/SobjectName__c.field-meta.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>SobjectName__c</fullName>
+    <description>The full API name of the object for which this workflow is executed. This is used primarily as a filter when querying metadata to look for active workflows.</description>
+    <externalId>false</externalId>
+    <fieldManageability>SubscriberControlled</fieldManageability>
+    <inlineHelpText>The full API name (e.g., &quot;Account&quot;, &quot;SBQQ__Quote__c&quot;) of the object for which this workflow is executed</inlineHelpText>
+    <label>Object API Name</label>
+    <length>40</length>
+    <required>true</required>
+    <type>Text</type>
+    <unique>false</unique>
+</CustomField>

--- a/force-app/main/default/objects/TriggerWorkflow__mdt/listViews/AllActive.listView-meta.xml
+++ b/force-app/main/default/objects/TriggerWorkflow__mdt/listViews/AllActive.listView-meta.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ListView xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>AllActive</fullName>
+    <columns>DeveloperName</columns>
+    <columns>IsActive__c</columns>
+    <columns>SobjectName__c</columns>
+    <columns>Priority__c</columns>
+    <filterScope>Everything</filterScope>
+    <filters>
+        <field>IsActive__c</field>
+        <operation>equals</operation>
+        <value>1</value>
+    </filters>
+    <label>All Active</label>
+</ListView>

--- a/force-app/main/default/objects/TriggerWorkflow__mdt/listViews/AllInctive.listView-meta.xml
+++ b/force-app/main/default/objects/TriggerWorkflow__mdt/listViews/AllInctive.listView-meta.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ListView xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>AllInctive</fullName>
+    <columns>DeveloperName</columns>
+    <columns>IsActive__c</columns>
+    <columns>SobjectName__c</columns>
+    <columns>Priority__c</columns>
+    <filterScope>Everything</filterScope>
+    <filters>
+        <field>IsActive__c</field>
+        <operation>equals</operation>
+        <value>0</value>
+    </filters>
+    <label>All Inactive</label>
+</ListView>

--- a/force-app/main/default/triggers/ApexTruthTrigger.trigger
+++ b/force-app/main/default/triggers/ApexTruthTrigger.trigger
@@ -9,8 +9,5 @@ trigger ApexTruthTrigger on ApexTruth__c (
             Schema.sobjectType.ApexTruth__c.getName());
 
     // Process all of the trigger workflows
-    service.process(new List<Type> {
-        ApexTruthTrackDmlWorkflow.class,
-        ApexTruthTrackTriggerWorkflow.class
-    });
+    service.process(service.getActiveWorkflows());
 }

--- a/force-app/main/default/triggers/ApexTruthTrigger.trigger
+++ b/force-app/main/default/triggers/ApexTruthTrigger.trigger
@@ -9,5 +9,5 @@ trigger ApexTruthTrigger on ApexTruth__c (
             Schema.sobjectType.ApexTruth__c.getName());
 
     // Process all of the trigger workflows
-    service.process(service.getActiveWorkflows());
+    service.processActiveWorkflows();
 }

--- a/force-app/main/default/triggers/CaseCommentWorkflowTrigger.trigger
+++ b/force-app/main/default/triggers/CaseCommentWorkflowTrigger.trigger
@@ -15,5 +15,5 @@ trigger CaseCommentWorkflowTrigger on CaseComment (
             Schema.sobjectType.CaseComment.getName());
 
     // Process all of the trigger workflows
-    service.process(service.getActiveWorkflows());
+    service.processActiveWorkflows();
 }

--- a/force-app/main/default/triggers/CaseCommentWorkflowTrigger.trigger
+++ b/force-app/main/default/triggers/CaseCommentWorkflowTrigger.trigger
@@ -15,7 +15,5 @@ trigger CaseCommentWorkflowTrigger on CaseComment (
             Schema.sobjectType.CaseComment.getName());
 
     // Process all of the trigger workflows
-    service.process(new List<Type> {
-        CaseCommentDebugWorkflow.class
-    });
+    service.process(service.getActiveWorkflows());
 }


### PR DESCRIPTION
This pr addresses #11 and actually #10 and #4 as well by deprecating and removing `TriggerWorkflow.isActive`. Instead the identification of active workflows is moved into each instance of `TriggerService`, and metadata leveraging new **Priority** and **Object API Name** fields control the order of execution of workflows.