### PR TITLE
Create scratch org with Tuna namespace

### DIFF
--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -5,7 +5,7 @@
       "default": true
     }
   ],
-  "namespace": "",
+  "namespace": "Tuna",
   "sfdcLoginUrl": "https://login.salesforce.com",
   "sourceApiVersion": "43.0"
 }


### PR DESCRIPTION
This pr resolves #18 by specifying the `namespace` attribute for new scratch orgs. For more information, see the Stack Exchange thread titled, "[Create scratch org with namespace?][1]"

[1]: https://salesforce.stackexchange.com/questions/234220/create-scratch-org-with-namespace