### PR TITLE
Configure workflow execution contexts with custom metadata

### DIFF
--- a/force-app/main/default/classes/AbstractSobjectSelector.cls
+++ b/force-app/main/default/classes/AbstractSobjectSelector.cls
@@ -1,0 +1,24 @@
+public abstract class AbstractSobjectSelector {
+
+    private DatabaseJockey jockey;
+
+    abstract List<Schema.SObjectField> getSobjectFields();
+
+    abstract Schema.SObjectType getSobjectType();
+
+    public AbstractSobjectSelector() {
+        this(DatabaseJockey.newInstance());
+    }
+
+    public AbstractSobjectSelector(DatabaseJockey jockey) {
+        this.jockey = jockey;
+    }
+
+    protected Soql.Query getQuery() {
+        return new Soql.Query(this.getSobjectFields(), this.getSobjectType());
+    }
+
+    protected List<SObject> execute(Soql.Query query) {
+        return this.jockey.query(query.toString());
+    }
+}

--- a/force-app/main/default/classes/AbstractSobjectSelector.cls
+++ b/force-app/main/default/classes/AbstractSobjectSelector.cls
@@ -19,6 +19,6 @@ public abstract class AbstractSobjectSelector {
     }
 
     protected List<SObject> execute(Soql.Query query) {
-        return this.jockey.query(query.toString());
+        return this.jockey.query(query.toSoql());
     }
 }

--- a/force-app/main/default/classes/AbstractSobjectSelector.cls-meta.xml
+++ b/force-app/main/default/classes/AbstractSobjectSelector.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>46.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/DatabaseJockey.cls
+++ b/force-app/main/default/classes/DatabaseJockey.cls
@@ -1,0 +1,83 @@
+public with sharing class DatabaseJockey {
+
+    /**
+     * Deletes a list of existing sObject records, such as individual accounts
+     * or contacts, from your organization’s data.
+     *
+     * @param recordsToDelete
+     *
+     * @return results from the DML operation
+     *
+     * @see https://developer.salesforce.com/docs/atlas.en-us.apexcode.meta/apexcode/apex_methods_system_database.htm
+     */
+    public List<Database.DeleteResult> del(List<SObject> recordsToDelete) {
+        return Database.delete(recordsToDelete, true);
+    }
+    
+    /**
+     * Adds an sObject, such as an individual account or contact,
+     * to your organization's data.
+     *
+     * @param recordToInsert
+     *
+     * @return result from the DML operation
+     *
+     * @see https://developer.salesforce.com/docs/atlas.en-us.apexcode.meta/apexcode/apex_methods_system_database.htm
+     */
+    public Database.SaveResult ins(SObject recordToInsert) {
+        return Database.insert(recordToInsert, true);
+    }
+    
+    /**
+     * Adds one or more sObjects, such as individual accounts or contacts,
+     * to your organization’s data.
+     *
+     * @param recordsToInsert
+     *
+     * @return results from the DML operation
+     *
+     * @see https://developer.salesforce.com/docs/atlas.en-us.apexcode.meta/apexcode/apex_methods_system_database.htm
+     */
+    public List<Database.SaveResult> ins(List<SObject> recordsToInsert) {
+        return Database.insert(recordsToInsert, true);
+    }
+
+    /**
+     * @return a fresh jockey to perform DML operations
+     */
+    public static DatabaseJockey newInstance() {
+        return new DatabaseJockey();
+    }
+
+    public List<SObject> query(String query) {
+        return Database.query(query);
+    }
+
+    /**
+     * Modifies an existing sObject record, such as an individual account
+     * or contact, in your organization's data.
+     *
+     * @param recordToUpdate
+     *
+     * @return result from the DML operation
+     *
+     * @see https://developer.salesforce.com/docs/atlas.en-us.apexcode.meta/apexcode/apex_methods_system_database.htm
+     */
+    public Database.SaveResult upd(SObject recordToUpdate) {
+        return Database.update(recordToUpdate, true);
+    }
+
+    /**
+     * Modifies one or more existing sObject records, such as individual
+     * accounts or contacts, in your organization’s data.
+     *
+     * @param recordsToUpdate
+     *
+     * @return results from the DML operation
+     *
+     * @see https://developer.salesforce.com/docs/atlas.en-us.apexcode.meta/apexcode/apex_methods_system_database.htm
+     */
+    public List<Database.SaveResult> upd(List<SObject> recordsToUpdate) {
+        return Database.update(recordsToUpdate, true);
+    }
+}

--- a/force-app/main/default/classes/DatabaseJockey.cls-meta.xml
+++ b/force-app/main/default/classes/DatabaseJockey.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>46.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/Soql.cls
+++ b/force-app/main/default/classes/Soql.cls
@@ -118,7 +118,9 @@ public with sharing class Soql {
                 new List<String> {
                     this.fieldDesc.getLocalName(),
                     EQUALS_OPERATOR,
-                    String.valueOf(this.value)
+                    this.value instanceof String
+                            ? inSingleQuotes((String)this.value)
+                            : String.valueOf(this.value)
                 },
                 Soql.SPACE_CHAR
             );
@@ -205,6 +207,37 @@ public with sharing class Soql {
         public Query expressWhere(ConditionExpression expr) {
             this.setWhereCondition(expr);
             return this;
+        }
+
+        public String getFromClause() {
+            return 'FROM ' + this.sobjectName;
+        }
+
+        public String getSelectClause() {
+            return 'SELECT ' + String.join(
+                this.fieldNames,
+                COMMA_CHAR + SPACE_CHAR
+            );
+        }
+
+        public String getWhereClause() {
+            return 'WHERE ' + this.whereCondition.toString();
+        }
+
+        public String toSoql() {
+
+            // Initialize the list of clauses
+            List<String> clauses = new List<String> {
+                this.getSelectClause(),
+                this.getFromClause()
+            };
+
+            // Add a WHERE clause if a condition exists
+            if (this.whereCondition != null) {
+                clauses.add(this.getWhereClause());
+            }
+
+            return String.join(clauses, SPACE_CHAR);
         }
 
         public void setWhereCondition(ConditionExpression value) {

--- a/force-app/main/default/classes/Soql.cls
+++ b/force-app/main/default/classes/Soql.cls
@@ -1,0 +1,214 @@
+public with sharing class Soql {
+
+    public static final String AND_OPERATOR = 'AND';
+
+    public static final String COMMA_CHAR = ',';
+
+    public static final String EQUALS_OPERATOR = '=';
+
+    public static final String INCLUDES_OPERATOR = 'INCLUDES';
+
+    public static final String SINGLE_QUOTE_CHAR = '\'';
+
+    public static final String SPACE_CHAR = ' ';
+
+    public static ConditionExpression expressAnd(
+        ConditionExpression expr1,
+        ConditionExpression expr2
+    ) {
+        return expressAnd(new List<ConditionExpression> { expr1, expr2 });
+    }
+
+    public static ConditionExpression expressAnd(
+        List<ConditionExpression> exprs
+    ) {
+        return new AndExpression(exprs);
+    }
+
+    public static ConditionExpression expressEquals(
+        Schema.SObjectField field,
+        Object value
+    ) {
+        return new EqualsExpression(field, value);
+    }
+
+    public static ConditionExpression expressIncludes(
+        Schema.SObjectField field,
+        Object value
+    ) {
+        return new IncludesExpression(field, value);
+    }
+
+    public static List<String> getFieldLocalNames(
+        List<Schema.SObjectField> fields
+    ) {
+        
+        // Initialize the list of field names
+        List<String> fieldNames = new List<String>();
+
+        for (Schema.SObjectField eachField : fields) {
+            fieldNames.add(eachField.getDescribe().getLocalName());
+        }
+
+        // Return the field names
+        return fieldNames;
+    }
+
+    public static String inParentheses(String value) {
+        return '(' + value + ')';
+    }
+
+    public static String inSingleQuotes(String value) {
+        return SINGLE_QUOTE_CHAR + value + SINGLE_QUOTE_CHAR;
+    }
+
+    public class AndExpression implements ConditionExpression {
+
+        private List<ConditionExpression> exprs;
+
+        public AndExpression(List<ConditionExpression> exprs) {
+            this.exprs = exprs;
+        }
+
+        public override String toString() {
+            
+            // Assume we have expressions to join
+            String exprString = exprs[0].toString();
+
+            // Join remaining elements
+            for (Integer i = 1; i < exprs.size(); i++) {
+                exprString = exprString
+                        + SPACE_CHAR
+                        + AND_OPERATOR
+                        + SPACE_CHAR
+                        + exprs[i];
+            }
+
+            // Return the total expression
+            return exprString;
+        }
+    }
+    
+    public interface ConditionExpression {
+        String toString();
+    }
+
+    public class EqualsExpression implements ConditionExpression {
+
+        private Schema.DescribeFieldResult fieldDesc;
+        private Object value;
+
+        public EqualsExpression(
+            Schema.SObjectField field,
+            Object value
+        ) {
+            this(field.getDescribe(), value);
+        }
+
+        public EqualsExpression(
+            Schema.DescribeFieldResult fieldDesc,
+            Object value
+        ) {
+            this.fieldDesc = fieldDesc;
+            this.value = value;
+        }
+
+        public override String toString() {
+            return String.join(
+                new List<String> {
+                    this.fieldDesc.getLocalName(),
+                    EQUALS_OPERATOR,
+                    String.valueOf(this.value)
+                },
+                Soql.SPACE_CHAR
+            );
+        }
+    }
+
+    public class IncludesExpression implements ConditionExpression {
+
+        private Schema.DescribeFieldResult fieldDesc;
+        private List<String> values;
+
+        public IncludesExpression(
+            Schema.SObjectField field,
+            Object value
+        ) {
+            this(
+                field.getDescribe(),
+                new List<String> { String.valueOf(value) }
+            );
+        }
+
+        public IncludesExpression(
+            Schema.DescribeFieldResult fieldDesc,
+            List<String> values
+        ) {
+            this.fieldDesc = fieldDesc;
+            this.values = values;
+        }
+
+        private List<String> getQuotedValues() {
+
+            // Initialize the list
+            List<String> quotedValues = new List<String>();
+
+            // Build the list
+            for (String value : this.values) {
+                quotedValues.add(inSingleQuotes(value));
+            }
+
+            // Return the list
+            return quotedValues;
+        }
+
+        public override String toString() {
+            return String.join(
+                new List<String> {
+                    this.fieldDesc.getLocalName(),
+                    INCLUDES_OPERATOR,
+                    inParentheses(
+                        String.join(
+                            this.getQuotedValues(),
+                            COMMA_CHAR
+                        )
+                    )
+                },
+                Soql.SPACE_CHAR
+            );
+        }
+    }
+
+    public class Query {
+        
+        private List<String> fieldNames;
+        
+        private String sobjectName;
+
+        private ConditionExpression whereCondition;
+
+        public Query(
+            List<Schema.SObjectField> fields,
+            Schema.SObjectType sobjectType
+        ) {
+            this(
+                getFieldLocalNames(fields),
+                sobjectType.getDescribe().getLocalName()
+            );
+        }
+
+        public Query(List<String> fieldNames, String sobjectName) {
+            this.fieldNames = fieldNames;
+            this.sobjectName = sobjectName;
+        }
+
+        public Query expressWhere(ConditionExpression expr) {
+            this.setWhereCondition(expr);
+            return this;
+        }
+
+        public void setWhereCondition(ConditionExpression value) {
+            this.whereCondition = value;
+        }
+    }
+}

--- a/force-app/main/default/classes/Soql.cls-meta.xml
+++ b/force-app/main/default/classes/Soql.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>46.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/SoqlQueryTest.cls
+++ b/force-app/main/default/classes/SoqlQueryTest.cls
@@ -1,0 +1,76 @@
+/**
+ * Class providing code coverage and functional validation for `Soql.Query`.
+ */
+@isTest
+private class SoqlQueryTest {
+
+    /**
+     * Verify behavior of `getSelectClause` and `getFromClause` with
+     * a simple query to SELECT Id,Name FROM Account WHERE Name = 'Acme'.
+     */
+    @isTest
+    private static void getAccountWhereClause() {
+
+        // Given
+        Schema.SObjectType sobjectType = Account.getSObjectType();
+
+        List<Schema.SObjectField> fields = new List<Schema.SObjectField> {
+            Account.Id,
+            Account.Name
+        };
+
+        Soql.Query query = new Soql.Query(fields, sobjectType);
+
+        // When
+        Test.startTest();
+
+        query.expressWhere(Soql.expressEquals(Account.Name, 'Acme'));
+
+        // Then
+        Test.stopTest();
+
+        System.assertEquals(
+            'WHERE Name = \'Acme\'',
+            query.getWhereClause()
+        );
+
+        System.assertEquals(
+            'SELECT Id, Name FROM Account WHERE Name = \'Acme\'',
+            query.toSoql()
+        );
+    }
+
+    /**
+     * Verify behavior of `getSelectClause` and `getFromClause` with
+     * a simple query to SELECT Id,Name FROM Account
+     */
+    @isTest
+    private static void getSelectFromAccountClause() {
+
+        // Given
+        Schema.SObjectType sobjectType = Account.getSObjectType();
+
+        List<Schema.SObjectField> fields = new List<Schema.SObjectField> {
+            Account.Id,
+            Account.Name
+        };
+
+        // When
+        Test.startTest();
+
+        Soql.Query query = new Soql.Query(fields, sobjectType);
+
+        // Then
+        Test.stopTest();
+
+        System.assertEquals(
+            'SELECT Id, Name',
+            query.getSelectClause()
+        );
+
+        System.assertEquals(
+            'FROM Account',
+            query.getFromClause()
+        );
+    }
+}

--- a/force-app/main/default/classes/SoqlQueryTest.cls-meta.xml
+++ b/force-app/main/default/classes/SoqlQueryTest.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>46.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/TriggerService.cls
+++ b/force-app/main/default/classes/TriggerService.cls
@@ -41,6 +41,8 @@ global with sharing class TriggerService {
      */
     private TriggerWorkflowContext context { get; set; }
 
+    private TriggerWorkflowSelector selector;
+
     /**
      * The static registry of trigger services that have been invoked
      * in the current transaction, where the key for each service is
@@ -60,10 +62,23 @@ global with sharing class TriggerService {
     private Map<String, TriggerWorkflow> workflowsByName { get; set; }
 
     global TriggerService(String sobjectName) {
+        this(
+            sobjectName,
+            TriggerWorkflowContext.getInstance(),
+            TriggerWorkflowSelector.newInstance()
+        );
+    }
+
+    global TriggerService(
+        String sobjectName,
+        TriggerWorkflowContext context,
+        TriggerWorkflowSelector selector
+    ) {
         this.sobjectName = sobjectName;
+        this.context = context;
+        this.selector = selector;
+
         this.activeWorkflows = new List<TriggerWorkflow>();
-        
-        this.context = new TriggerWorkflowContext();
         this.workflowsByName = new Map<String, TriggerWorkflow>();
     }
 
@@ -71,19 +86,15 @@ global with sharing class TriggerService {
 
         // If there are no workflows cached, look for active ones
         if (this.activeWorkflows.isEmpty()) {
-            for (TriggerWorkflow__mdt eachEntry : [
-                SELECT
-                    DeveloperName,
-                    Id
-                FROM TriggerWorkflow__mdt
-                WHERE
-                    SobjectName__c = :this.sobjectName AND
-                    IsActive__c = TRUE
-                ORDER BY
-                    Priority__c ASC
-            ]) {
+            for (TriggerWorkflow__mdt eachEntry
+                    : this.selector.selectActiveBySobjectNameAndContext(
+                        this.sobjectName,
+                        this.context
+                    )
+            ) {
                 this.activeWorkflows.add(
-                        this.getWorkflow(eachEntry.DeveloperName));
+                    this.getWorkflow(eachEntry.DeveloperName)
+                );
             }
         }
 
@@ -101,7 +112,10 @@ global with sharing class TriggerService {
      *             Schema.sobjectType.ApexTruth__c.getName()
      * @return the TriggerService object for the given Sobject
      */
-    global static TriggerService getInstance(String name, TriggerWorkflowContext context) {
+    global static TriggerService getInstance(
+        String name,
+        TriggerWorkflowContext context
+    ) {
         
         // If no service has been initialized yet for the given Sobject,
         // first initialize and register the service.

--- a/force-app/main/default/classes/TriggerWorkflowSelector.cls
+++ b/force-app/main/default/classes/TriggerWorkflowSelector.cls
@@ -1,7 +1,7 @@
-public with sharing class TriggerWorkflowSelector
+global with sharing class TriggerWorkflowSelector
 extends AbstractSobjectSelector {
 
-    public static Schema.SObjectField getOnBeforeOrAfterField(
+    global static Schema.SObjectField getOnBeforeOrAfterField(
         TriggerWorkflowContext context
     ) {
         return context.isBefore
@@ -11,7 +11,7 @@ extends AbstractSobjectSelector {
                         : null;
     }
 
-    public static Schema.SObjectField getOnCrudField(
+    global static Schema.SObjectField getOnCrudField(
         TriggerWorkflowContext context
     ) {
         Schema.SObjectField field = null;
@@ -32,7 +32,7 @@ extends AbstractSobjectSelector {
         return field;
     }
 
-    public List<Schema.SObjectField> getSobjectFields() {
+    global List<Schema.SObjectField> getSobjectFields() {
         return new List<Schema.SObjectField> {
             TriggerWorkflow__mdt.DeveloperName,
             TriggerWorkflow__mdt.Id,
@@ -41,11 +41,15 @@ extends AbstractSobjectSelector {
         };
     }
 
-    public Schema.SObjectType getSobjectType() {
+    global Schema.SObjectType getSobjectType() {
         return TriggerWorkflow__mdt.sobjectType;
     }
 
-    public List<TriggerWorkflow__mdt> selectActiveBySobjectNameAndContext(
+    global static TriggerWorkflowSelector newInstance() {
+        return new TriggerWorkflowSelector();
+    }
+
+    global List<TriggerWorkflow__mdt> selectActiveBySobjectNameAndContext(
         String sobjectName,
         TriggerWorkflowContext context
     ) {

--- a/force-app/main/default/classes/TriggerWorkflowSelector.cls
+++ b/force-app/main/default/classes/TriggerWorkflowSelector.cls
@@ -1,0 +1,77 @@
+public with sharing class TriggerWorkflowSelector
+extends AbstractSobjectSelector {
+
+    public static Schema.SObjectField getOnBeforeOrAfterField(
+        TriggerWorkflowContext context
+    ) {
+        return context.isBefore
+                ? TriggerWorkflow__mdt.IsOnBefore__c
+                : context.isAfter
+                        ? TriggerWorkflow__mdt.IsOnAfter__c
+                        : null;
+    }
+
+    public static Schema.SObjectField getOnCrudField(
+        TriggerWorkflowContext context
+    ) {
+        Schema.SObjectField field = null;
+
+        if (context.isUpdate) {
+            field = TriggerWorkflow__mdt.IsOnUpdate__c;
+        }
+        else if (context.isInsert) {
+            field = TriggerWorkflow__mdt.IsOnInsert__c;
+        }
+        else if (context.isDelete) {
+            field = TriggerWorkflow__mdt.IsOnDelete__c;
+        }
+        else if (context.isUndelete) {
+            field = TriggerWorkflow__mdt.IsOnUndelete__c;
+        }
+
+        return field;
+    }
+
+    public List<Schema.SObjectField> getSobjectFields() {
+        return new List<Schema.SObjectField> {
+            TriggerWorkflow__mdt.DeveloperName,
+            TriggerWorkflow__mdt.Id,
+            TriggerWorkflow__mdt.IsActive__c,
+            TriggerWorkflow__mdt.SobjectName__c
+        };
+    }
+
+    public Schema.SObjectType getSobjectType() {
+        return TriggerWorkflow__mdt.sobjectType;
+    }
+
+    public List<TriggerWorkflow__mdt> selectActiveBySobjectNameAndContext(
+        String sobjectName,
+        TriggerWorkflowContext context
+    ) {
+        return this.execute(
+            this.getQuery().expressWhere(
+                Soql.expressAnd(
+                    new List<Soql.ConditionExpression> {
+                        Soql.expressEquals(
+                            TriggerWorkflow__mdt.SobjectName__c,
+                            sobjectName
+                        ),
+                        Soql.expressEquals(
+                            getOnBeforeOrAfterField(context),
+                            true
+                        ),
+                        Soql.expressEquals(
+                            getOnCrudField(context),
+                            true
+                        ),
+                        Soql.expressEquals(
+                            TriggerWorkflow__mdt.IsActive__c,
+                            true
+                        )
+                    }
+                )
+            )
+        );
+    }
+}

--- a/force-app/main/default/classes/TriggerWorkflowSelector.cls-meta.xml
+++ b/force-app/main/default/classes/TriggerWorkflowSelector.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>46.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/customMetadata/TriggerWorkflow.ApexTruthTrackDmlWorkflow.md-meta.xml
+++ b/force-app/main/default/customMetadata/TriggerWorkflow.ApexTruthTrackDmlWorkflow.md-meta.xml
@@ -7,6 +7,30 @@
         <value xsi:type="xsd:boolean">true</value>
     </values>
     <values>
+        <field>IsOnAfter__c</field>
+        <value xsi:type="xsd:boolean">true</value>
+    </values>
+    <values>
+        <field>IsOnBefore__c</field>
+        <value xsi:type="xsd:boolean">true</value>
+    </values>
+    <values>
+        <field>IsOnDelete__c</field>
+        <value xsi:type="xsd:boolean">false</value>
+    </values>
+    <values>
+        <field>IsOnInsert__c</field>
+        <value xsi:type="xsd:boolean">true</value>
+    </values>
+    <values>
+        <field>IsOnUndelete__c</field>
+        <value xsi:type="xsd:boolean">false</value>
+    </values>
+    <values>
+        <field>IsOnUpdate__c</field>
+        <value xsi:type="xsd:boolean">true</value>
+    </values>
+    <values>
         <field>Priority__c</field>
         <value xsi:type="xsd:double">100.0</value>
     </values>

--- a/force-app/main/default/customMetadata/TriggerWorkflow.ApexTruthTrackTriggerWorkflow.md-meta.xml
+++ b/force-app/main/default/customMetadata/TriggerWorkflow.ApexTruthTrackTriggerWorkflow.md-meta.xml
@@ -7,6 +7,30 @@
         <value xsi:type="xsd:boolean">true</value>
     </values>
     <values>
+        <field>IsOnAfter__c</field>
+        <value xsi:type="xsd:boolean">true</value>
+    </values>
+    <values>
+        <field>IsOnBefore__c</field>
+        <value xsi:type="xsd:boolean">true</value>
+    </values>
+    <values>
+        <field>IsOnDelete__c</field>
+        <value xsi:type="xsd:boolean">false</value>
+    </values>
+    <values>
+        <field>IsOnInsert__c</field>
+        <value xsi:type="xsd:boolean">true</value>
+    </values>
+    <values>
+        <field>IsOnUndelete__c</field>
+        <value xsi:type="xsd:boolean">false</value>
+    </values>
+    <values>
+        <field>IsOnUpdate__c</field>
+        <value xsi:type="xsd:boolean">true</value>
+    </values>
+    <values>
         <field>Priority__c</field>
         <value xsi:type="xsd:double">100.0</value>
     </values>

--- a/force-app/main/default/customMetadata/TriggerWorkflow.CaseCommentDebugWorkflow.md-meta.xml
+++ b/force-app/main/default/customMetadata/TriggerWorkflow.CaseCommentDebugWorkflow.md-meta.xml
@@ -36,6 +36,6 @@
     </values>
     <values>
         <field>SobjectName__c</field>
-        <value xsi:type="xsd:string">ApexTruth__c</value>
+        <value xsi:type="xsd:string">CaseComment</value>
     </values>
 </CustomMetadata>

--- a/force-app/main/default/customMetadata/TriggerWorkflow.CaseCommentDebugWorkflow.md-meta.xml
+++ b/force-app/main/default/customMetadata/TriggerWorkflow.CaseCommentDebugWorkflow.md-meta.xml
@@ -7,6 +7,30 @@
         <value xsi:type="xsd:boolean">true</value>
     </values>
     <values>
+        <field>IsOnAfter__c</field>
+        <value xsi:type="xsd:boolean">true</value>
+    </values>
+    <values>
+        <field>IsOnBefore__c</field>
+        <value xsi:type="xsd:boolean">true</value>
+    </values>
+    <values>
+        <field>IsOnDelete__c</field>
+        <value xsi:type="xsd:boolean">false</value>
+    </values>
+    <values>
+        <field>IsOnInsert__c</field>
+        <value xsi:type="xsd:boolean">true</value>
+    </values>
+    <values>
+        <field>IsOnUndelete__c</field>
+        <value xsi:type="xsd:boolean">false</value>
+    </values>
+    <values>
+        <field>IsOnUpdate__c</field>
+        <value xsi:type="xsd:boolean">true</value>
+    </values>
+    <values>
         <field>Priority__c</field>
         <value xsi:type="xsd:double">100.0</value>
     </values>

--- a/force-app/main/default/layouts/TriggerWorkflow__mdt-Trigger Workflow Layout.layout-meta.xml
+++ b/force-app/main/default/layouts/TriggerWorkflow__mdt-Trigger Workflow Layout.layout-meta.xml
@@ -43,6 +43,41 @@
         <customLabel>false</customLabel>
         <detailHeading>false</detailHeading>
         <editHeading>true</editHeading>
+        <label>Context Information</label>
+        <layoutColumns>
+            <layoutItems>
+                <behavior>Edit</behavior>
+                <field>IsOnInsert__c</field>
+            </layoutItems>
+            <layoutItems>
+                <behavior>Edit</behavior>
+                <field>IsOnUpdate__c</field>
+            </layoutItems>
+            <layoutItems>
+                <behavior>Edit</behavior>
+                <field>IsOnDelete__c</field>
+            </layoutItems>
+            <layoutItems>
+                <behavior>Edit</behavior>
+                <field>IsOnUndelete__c</field>
+            </layoutItems>
+        </layoutColumns>
+        <layoutColumns>
+            <layoutItems>
+                <behavior>Edit</behavior>
+                <field>IsOnBefore__c</field>
+            </layoutItems>
+            <layoutItems>
+                <behavior>Edit</behavior>
+                <field>IsOnAfter__c</field>
+            </layoutItems>
+        </layoutColumns>
+        <style>TwoColumnsTopToBottom</style>
+    </layoutSections>
+    <layoutSections>
+        <customLabel>false</customLabel>
+        <detailHeading>false</detailHeading>
+        <editHeading>true</editHeading>
         <label>System Information</label>
         <layoutColumns>
             <layoutItems>

--- a/force-app/main/default/objects/TriggerWorkflow__mdt/fields/IsOnAfter__c.field-meta.xml
+++ b/force-app/main/default/objects/TriggerWorkflow__mdt/fields/IsOnAfter__c.field-meta.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>IsOnAfter__c</fullName>
+    <defaultValue>false</defaultValue>
+    <description>Whether the workflow should execute in "after" contexts</description>
+    <externalId>false</externalId>
+    <fieldManageability>SubscriberControlled</fieldManageability>
+    <inlineHelpText>Whether the workflow should execute in "after" contexts</inlineHelpText>
+    <label>On After</label>
+    <type>Checkbox</type>
+</CustomField>

--- a/force-app/main/default/objects/TriggerWorkflow__mdt/fields/IsOnBefore__c.field-meta.xml
+++ b/force-app/main/default/objects/TriggerWorkflow__mdt/fields/IsOnBefore__c.field-meta.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>IsOnBefore__c</fullName>
+    <defaultValue>false</defaultValue>
+    <description>Whether the workflow should execute in "before" contexts</description>
+    <externalId>false</externalId>
+    <fieldManageability>SubscriberControlled</fieldManageability>
+    <inlineHelpText>Whether the workflow should execute in "before" contexts</inlineHelpText>
+    <label>On Before</label>
+    <type>Checkbox</type>
+</CustomField>

--- a/force-app/main/default/objects/TriggerWorkflow__mdt/fields/IsOnDelete__c.field-meta.xml
+++ b/force-app/main/default/objects/TriggerWorkflow__mdt/fields/IsOnDelete__c.field-meta.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>IsOnDelete__c</fullName>
+    <defaultValue>false</defaultValue>
+    <description>Whether the workflow should execute in "delete" contexts</description>
+    <externalId>false</externalId>
+    <fieldManageability>SubscriberControlled</fieldManageability>
+    <inlineHelpText>Whether the workflow should execute in "delete" contexts</inlineHelpText>
+    <label>On Delete</label>
+    <type>Checkbox</type>
+</CustomField>

--- a/force-app/main/default/objects/TriggerWorkflow__mdt/fields/IsOnInsert__c.field-meta.xml
+++ b/force-app/main/default/objects/TriggerWorkflow__mdt/fields/IsOnInsert__c.field-meta.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>IsOnInsert__c</fullName>
+    <defaultValue>false</defaultValue>
+    <description>Whether the workflow should execute in "insert" contexts</description>
+    <externalId>false</externalId>
+    <fieldManageability>SubscriberControlled</fieldManageability>
+    <inlineHelpText>Whether the workflow should execute in "insert" contexts</inlineHelpText>
+    <label>On Insert</label>
+    <type>Checkbox</type>
+</CustomField>

--- a/force-app/main/default/objects/TriggerWorkflow__mdt/fields/IsOnUndelete__c.field-meta.xml
+++ b/force-app/main/default/objects/TriggerWorkflow__mdt/fields/IsOnUndelete__c.field-meta.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>IsOnUndelete__c</fullName>
+    <defaultValue>false</defaultValue>
+    <description>Whether the workflow should execute in "undelete" contexts</description>
+    <externalId>false</externalId>
+    <fieldManageability>SubscriberControlled</fieldManageability>
+    <inlineHelpText>Whether the workflow should execute in "undelete" contexts</inlineHelpText>
+    <label>On Undelete</label>
+    <type>Checkbox</type>
+</CustomField>

--- a/force-app/main/default/objects/TriggerWorkflow__mdt/fields/IsOnUpdate__c.field-meta.xml
+++ b/force-app/main/default/objects/TriggerWorkflow__mdt/fields/IsOnUpdate__c.field-meta.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>IsOnUpdate__c</fullName>
+    <defaultValue>false</defaultValue>
+    <description>Whether the workflow should execute in "update" contexts</description>
+    <externalId>false</externalId>
+    <fieldManageability>SubscriberControlled</fieldManageability>
+    <inlineHelpText>Whether the workflow should execute in "update" contexts</inlineHelpText>
+    <label>On Update</label>
+    <type>Checkbox</type>
+</CustomField>

--- a/force-app/main/default/objects/TriggerWorkflow__mdt/listViews/AllActive.listView-meta.xml
+++ b/force-app/main/default/objects/TriggerWorkflow__mdt/listViews/AllActive.listView-meta.xml
@@ -5,6 +5,12 @@
     <columns>IsActive__c</columns>
     <columns>SobjectName__c</columns>
     <columns>Priority__c</columns>
+    <columns>IsOnInsert__c</columns>
+    <columns>IsOnUpdate__c</columns>
+    <columns>IsOnDelete__c</columns>
+    <columns>IsOnBefore__c</columns>
+    <columns>IsOnAfter__c</columns>
+    <columns>IsOnUndelete__c</columns>
     <filterScope>Everything</filterScope>
     <filters>
         <field>IsActive__c</field>

--- a/force-app/main/default/objects/TriggerWorkflow__mdt/listViews/AllInactive.listView-meta.xml
+++ b/force-app/main/default/objects/TriggerWorkflow__mdt/listViews/AllInactive.listView-meta.xml
@@ -1,10 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ListView xmlns="http://soap.sforce.com/2006/04/metadata">
-    <fullName>AllInctive</fullName>
+    <fullName>AllInactive</fullName>
     <columns>DeveloperName</columns>
     <columns>IsActive__c</columns>
     <columns>SobjectName__c</columns>
     <columns>Priority__c</columns>
+    <columns>IsOnInsert__c</columns>
+    <columns>IsOnUpdate__c</columns>
+    <columns>IsOnDelete__c</columns>
+    <columns>IsOnBefore__c</columns>
+    <columns>IsOnAfter__c</columns>
+    <columns>IsOnUndelete__c</columns>
     <filterScope>Everything</filterScope>
     <filters>
         <field>IsActive__c</field>

--- a/force-app/main/default/triggers/ApexTruthTrigger.trigger
+++ b/force-app/main/default/triggers/ApexTruthTrigger.trigger
@@ -6,7 +6,7 @@ trigger ApexTruthTrigger on ApexTruth__c (
     // For readability, get a handle on the TriggerService object
     // for this Sobject type
     TriggerService service = TriggerService.getInstance(
-        Schema.sobjectType.ApexTruth__c.getName(),
+        Schema.sobjectType.ApexTruth__c.getLocalName(),
         TriggerWorkflowContext.getInstance()
     );
 

--- a/force-app/main/default/triggers/CaseCommentWorkflowTrigger.trigger
+++ b/force-app/main/default/triggers/CaseCommentWorkflowTrigger.trigger
@@ -12,7 +12,7 @@ trigger CaseCommentWorkflowTrigger on CaseComment (
     // For readability, get a handle on the TriggerService object
     // for this Sobject type
     TriggerService service = TriggerService.getInstance(
-        Schema.sobjectType.CaseComment.getName(),
+        Schema.sobjectType.CaseComment.getLocalName(),
         TriggerWorkflowContext.getInstance()
     );
 


### PR DESCRIPTION
This pr resolves #6 by making the `before`/`after` and `insert`/`update`/`delete` context determination for into custom metadata. Six new fields are introduced on `TriggerWorkflow__mdt` to handle this.

Field Label | Field Name
----- | -----
On Insert | `OnInsert__c`
On Update | `OnUpdate__c`
On Delete | `OnDelete__c`
On Before | `OnBefore__c`
On After | `OnAfter__c`
On Undelete | `OnUndelete__c`